### PR TITLE
fix: accept numbers as keys for ngx.shared.DICT methods

### DIFF
--- a/library/ngx.lua
+++ b/library/ngx.lua
@@ -1249,6 +1249,12 @@ ngx.shared = {}
 ---@class ngx.shared.DICT
 local DICT = {}
 
+--- Valid key types for ngx.shared.DICT
+---
+---@alias ngx.shared.DICT.key
+---| string
+---| number
+
 --- Valid values for ngx.shared.DICT
 ---@alias ngx.shared.DICT.value
 ---| string
@@ -1269,7 +1275,7 @@ local DICT = {}
 ---
 --- If the user flags is `0` (the default), then no flags value will be returned.
 ---
----@param key string
+---@param  key ngx.shared.DICT.key
 ---@return ngx.shared.DICT.value? value
 ---@return ngx.shared.DICT.flags|string|nil flags_or_error
 function DICT:get(key) end
@@ -1280,7 +1286,7 @@ function DICT:get(key) end
 ---
 --- Note that the value of an expired key is not guaranteed to be available so one should never rely on the availability of expired items.
 ---
----@param  key              string
+---@param  key ngx.shared.DICT.key
 ---@return ngx.shared.DICT.value? value
 ---@return ngx.shared.DICT.flags|string flags_or_error
 ---@return boolean          stale
@@ -1319,7 +1325,7 @@ function DICT:get_stale(key) end
 ---
 --- Please note that while internally the key-value pair is set atomically, the atomicity does not go across the method call boundary.
 ---
----@param  key      string
+---@param  key      ngx.shared.DICT.key
 ---@param  value    ngx.shared.DICT.value
 ---@param  exptime? ngx.shared.DICT.exptime
 ---@param  flags?   ngx.shared.DICT.flags
@@ -1330,7 +1336,7 @@ function DICT:set(key, value, exptime, flags) end
 
 --- Similar to the `set` method, but never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return `nil` and the string "no memory".
 ---
----@param  key      string
+---@param  key      ngx.shared.DICT.key
 ---@param  value    ngx.shared.DICT.value
 ---@param  exptime? ngx.shared.DICT.exptime
 ---@param  flags?   ngx.shared.DICT.flags
@@ -1343,7 +1349,7 @@ function DICT:safe_set(key, value, exptime, flags) end
 ---
 --- If the `key` argument already exists in the dictionary (and not expired for sure), the `success` return value will be `false` and the `err` return value will be `"exists"`.
 ---
----@param  key      string
+---@param  key      ngx.shared.DICT.key
 ---@param  value    ngx.shared.DICT.value
 ---@param  exptime? ngx.shared.DICT.exptime
 ---@param  flags?   ngx.shared.DICT.flags
@@ -1354,7 +1360,7 @@ function DICT:add(key, value, exptime, flags) end
 
 --- Similar to the `add` method, but never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return `nil` and the string "no memory".
 ---
----@param  key      string
+---@param  key      ngx.shared.DICT.key
 ---@param  value    ngx.shared.DICT.value
 ---@param  exptime? ngx.shared.DICT.exptime
 ---@param  flags?   ngx.shared.DICT.flags
@@ -1367,7 +1373,7 @@ function DICT:safe_add(key, value, exptime, flags) end
 ---
 --- If the `key` argument does *not* exist in the dictionary (or expired already), the `success` return value will be `false` and the `err` return value will be `"not found"`.
 ---
----@param  key      string
+---@param  key      ngx.shared.DICT.key
 ---@param  value    ngx.shared.DICT.value
 ---@param  exptime? ngx.shared.DICT.exptime
 ---@param  flags?   ngx.shared.DICT.flags
@@ -1380,7 +1386,7 @@ function DICT:replace(key, value, exptime, flags) end
 ---
 --- It is equivalent to `ngx.shared.DICT:set(key, nil)`.
 ---
----@param key string
+---@param key ngx.shared.DICT.key
 function DICT:delete(key) end
 
 --- Increments the (numerical) value for `key` by the step value `value`. Returns the new resulting number if the operation is successfully completed or `nil` and an error message otherwise.
@@ -1415,7 +1421,7 @@ function DICT:delete(key) end
 --- The `value` argument and `init` argument can be any valid Lua numbers, like negative numbers or floating-point numbers.
 ---
 ---
----@param  key       string
+---@param  key       ngx.shared.DICT.key
 ---@param  value     number
 ---@param  init?     number
 ---@param  init_ttl? ngx.shared.DICT.exptime
@@ -1435,7 +1441,7 @@ function DICT:incr(key, value, init, init_ttl) end
 ---
 --- It never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return `nil` and the string "no memory".
 ---
----@param  key     string
+---@param  key     ngx.shared.DICT.key
 ---@param  value   ngx.shared.DICT.list_value
 ---@return number? len    # number of elements in the list after the push operation
 ---@return ngx.shared.DICT.error? error
@@ -1443,7 +1449,7 @@ function DICT:lpush(key, value) end
 
 --- Similar to the `lpush` method, but inserts the specified (numerical or string) `value` at the tail of the list named `key`.
 ---
----@param  key     string
+---@param  key     ngx.shared.DICT.key
 ---@param  value   ngx.shared.DICT.list_value
 ---@return number? len    # number of elements in the list after the push operation
 ---@return ngx.shared.DICT.error? error
@@ -1453,7 +1459,7 @@ function DICT:rpush(key, value) end
 ---
 --- If `key` does not exist, it will return `nil`. When the `key` already takes a value that is not a list, it will return `nil` and `"value not a list"`.
 ---
----@param  key     string
+---@param  key     ngx.shared.DICT.key
 ---@return ngx.shared.DICT.list_value? item
 ---@return ngx.shared.DICT.error? error
 function DICT:lpop(key) end
@@ -1462,7 +1468,7 @@ function DICT:lpop(key) end
 ---
 --- If `key` does not exist, it will return `nil`. When the `key` already takes a value that is not a list, it will return `nil` and `"value not a list"`.
 ---
----@param  key     string
+---@param  key     ngx.shared.DICT.key
 ---@return ngx.shared.DICT.list_value? item
 ---@return ngx.shared.DICT.error? error
 function DICT:rpop(key) end
@@ -1471,7 +1477,7 @@ function DICT:rpop(key) end
 ---
 --- If key does not exist, it is interpreted as an empty list and 0 is returned. When the `key` already takes a value that is not a list, it will return `nil` and `"value not a list"`.
 ---
----@param key string
+---@param  key     ngx.shared.DICT.key
 ---@return number? len
 ---@return ngx.shared.DICT.error? error
 function DICT:llen(key) end
@@ -1495,7 +1501,7 @@ function DICT:llen(key) end
 ---  local ttl, err = cats:ttl("Marry")
 ---  ngx.say(ttl) -- 0.3
 --- ```
----@param  key     string
+---@param  key     ngx.shared.DICT.key
 ---@return number? ttl
 ---@return ngx.shared.DICT.error? error
 function DICT:ttl(key) end
@@ -1518,7 +1524,7 @@ function DICT:ttl(key) end
 ---  ngx.say(val) -- "a nice cat"
 --- ```
 ---
----@param  key     string
+---@param  key     ngx.shared.DICT.key
 ---@param  exptime ngx.shared.DICT.exptime
 ---@return boolean ok
 ---@return ngx.shared.DICT.error? error


### PR DESCRIPTION
This updates the annotations on the ngx.shared.DICT methods to accept numbers as keys in addition to strings.

Technically speaking, all of the shdict methods implemented in [resty.core.shdict][1] will accept any non-nil type as a key so long as it can be coerced to a string with `tostring()` (yes, even tables, booleans, and userdata like `ngx.null`). However, this does not include _all_ shdict methods. Notably, list methods like `lpush()`/`lpop()` will raise an error if non-string, non-number values are used as keys.

While I'd argue that using floats as keys is a bad/unsafe practice (integers should be just fine), I don't really want to split hairs any further on this.

[1]: https://github.com/openresty/lua-resty-core/blob/31fae862a1ed64033591f991fadb0dd80358ba0b/lib/resty/core/shdict.lua