### PR TITLE
chore: namespace {tcp,udp}sock classes

### DIFF
--- a/library/ngx.lua
+++ b/library/ngx.lua
@@ -3095,12 +3095,18 @@ function tcpsock:receiveany(max) end
 ---
 ---@alias ngx.socket.tcp.iterator fun(size:number|nil):string,string,any
 ---
----@overload fun(self:ngx.socket.tcp, size:number, options:table):ngx.socket.tcp.iterator
+---@overload fun(self:ngx.socket.tcp, size:number, options:ngx.socket.tcp.receiveuntil.opts|nil):ngx.socket.tcp.iterator
 ---
 ---@param pattern string
----@param options? table
+---@param options? ngx.socket.tcp.receiveuntil.opts
 ---@return ngx.socket.tcp.iterator
 function tcpsock:receiveuntil(pattern, options) end
+
+
+---@class ngx.socket.tcp.receiveuntil.opts
+---
+---@field inclusive? boolean # takes a boolean value to control whether to include the pattern string in the returned data string. Default to `false`.
+
 
 --- Closes the current TCP or stream unix domain socket. It returns the `1` in case of success and returns `nil` with a string describing the error otherwise.
 ---


### PR DESCRIPTION
It always bugged me that these weren't namespaced from the get-go.

This updates `tcpsock` and `udpsock` class names to `ngx.socket.tcp` and `ngx.socket.udp`, respectively. Note that this is _technically_ a breaking change for anyone who might be using these classes directly in their own projects (probably uncommon), but I think it's worth it to introduce more order to our typedefs.

Additionally, there are couple minor fixes for nilable fields in some option classes, and I added a definition for `ngx.socket.tcp.receiveuntil.opts`.