### PR TITLE
annotation updates

### DIFF
--- a/library/ngx.lua
+++ b/library/ngx.lua
@@ -567,7 +567,7 @@ function ngx.worker.pid() end
 ---
 --- This string field indicates the current NGINX subsystem the current Lua environment is based on. For this module, this field always takes the string value `"http"`.
 --- For `ngx_stream_lua_module`, however, this field takes the value `"stream"`.
----@field subsystem '"http"'|'"stream"'
+---@field subsystem "http"|"stream"
 ---
 --- This field takes an integral value indicating the version number of the current NGINX core being used. For example, the version number `1.4.3` results in the Lua number 1004003.
 ---@field nginx_version number
@@ -1293,11 +1293,11 @@ function DICT:get(key) end
 function DICT:get_stale(key) end
 
 ---@alias ngx.shared.DICT.error string
----| '"no memory"'        # not enough available memory to store a value
----| '"exists"'           # called add() on an existing value
----| '"not found"'        # called a method (replace/ttl/expire) on an absent value
----| '"not a number"'     # called incr() on a non-number value
----| '"value not a list"' # called list methods (lpush/lpop/rpush/rpop/llen) on a non-list value
+---| "no memory"        # not enough available memory to store a value
+---| "exists"           # called add() on an existing value
+---| "not found"        # called a method (replace/ttl/expire) on an absent value
+---| "not a number"     # called incr() on a non-number value
+---| "value not a list" # called list methods (lpush/lpop/rpush/rpop/llen) on a non-list value
 
 --- Optional user flags associated with a shm value.
 ---
@@ -1687,7 +1687,7 @@ ngx.var.host = nil
 ngx.var.hostname = nil
 
 --- “on” if connection operates in SSL mode, or an empty string otherwise
----@type string '"on"'|'""'
+---@type string "on"|""
 ngx.var.https = nil
 
 --- “?” if a request line has arguments, or an empty string otherwise
@@ -2041,7 +2041,7 @@ function ngx.req.set_body_data(data) end
 ---
 ---@param max_args? number
 ---@return table args
----@return string|'"truncated"' error
+---@return string|"truncated" error
 function ngx.req.get_post_args(max_args) end
 
 --- Returns a Lua table holding all the current request URL query arguments. An optional `tab` argument can be used to reuse the table returned by this method.
@@ -2134,7 +2134,7 @@ function ngx.req.get_post_args(max_args) end
 ---@param max_args? number
 ---@param tab? table
 ---@return table args
----@return string|'"truncated"' error
+---@return string|"truncated" error
 function ngx.req.get_uri_args(max_args, tab) end
 
 --- Rewrite the current request's (parsed) URI by the `uri` argument. The `uri` argument must be a Lua string and cannot be of zero length, or a Lua exception will be thrown.
@@ -2439,7 +2439,7 @@ function ngx.req.clear_header(header_name) end
 ---@param max_headers? number
 ---@param raw? boolean
 ---@return table<string, string|string[]> headers
----@return string|'"truncated"' error
+---@return string|"truncated" error
 function ngx.req.get_headers(max_headers, raw) end
 
 --- Explicitly discard the request body, i.e., read the data on the connection and throw it away immediately (without using the request body by any means).
@@ -2628,7 +2628,7 @@ function ngx.encode_args(args) end
 ---@param  str                  string
 ---@param  max_args?            number
 ---@return table                args
----@return string|'"truncated"' error
+---@return string|"truncated" error
 function ngx.decode_args(str, max_args) end
 
 ngx.socket = {}
@@ -3003,7 +3003,7 @@ function tcpsock:send(data) end
 ---
 ---@overload fun(self:ngx.socket.tcp, size:number):string,string,string
 ---
----@param  pattern? '"*a"'|'"*l"'
+---@param  pattern? "*a"|"*l"
 ---@return string? data
 ---@return string? error
 ---@return string? partial
@@ -3257,11 +3257,11 @@ function tcpsock:settimeouts(connect_timeout, send_timeout, read_timeout) end
 function tcpsock:setoption(option, value) end
 
 ---@alias ngx.socket.tcp.setoption.option
----| '"keepalive"'   # enable or disable keepalive
----| '"reuseaddr"'   # reuse addr options
----| '"tcp-nodelay"' # disables the Nagle's algorithm for the connection.
----| '"sndbuf"'      # max send buffer size (in bytes)
----| '"rcvbuf"'      # max receive bufer size (in bytes)
+---| "keepalive"   # enable or disable keepalive
+---| "reuseaddr"   # reuse addr options
+---| "tcp-nodelay" # disables the Nagle's algorithm for the connection.
+---| "sndbuf"      # max send buffer size (in bytes)
+---| "rcvbuf"      # max receive bufer size (in bytes)
 
 --- Puts the current socket's connection immediately into the cosocket built-in connection pool and keep it alive until other `connect` method calls request it or the associated maximal idle timeout is expired.
 ---
@@ -3394,20 +3394,20 @@ function ngx.socket.stream() end
 ngx.arg = {}
 
 ---@alias ngx.phase.name
----| '"init"'
----| '"init_worker"'
----| '"ssl_cert"'
----| '"ssl_session_fetch"'
----| '"ssl_session_store"'
----| '"set"'
----| '"rewrite"'
----| '"balancer"'
----| '"access"'
----| '"content"'
----| '"header_filter"'
----| '"body_filter"'
----| '"log"'
----| '"timer"'
+---| "init"
+---| "init_worker"
+---| "ssl_cert"
+---| "ssl_session_fetch"
+---| "ssl_session_store"
+---| "set"
+---| "rewrite"
+---| "balancer"
+---| "access"
+---| "content"
+---| "header_filter"
+---| "body_filter"
+---| "log"
+---| "timer"
 
 --- Retrieves the current running phase name.
 ---
@@ -3573,7 +3573,7 @@ function ngx.redirect(uri, status) end
 ---
 ---@param callback fun()
 ---@return boolean ok
----@return string|'"lua_check_client_abort is off"'|'"duplicate call"' error
+---@return string|"lua_check_client_abort is off"|"duplicate call" error
 function ngx.on_abort(callback) end
 
 --- Does an internal redirect to `uri` with `args` and is similar to the `echo_exec` directive of the `echo-nginx-module`.
@@ -4268,7 +4268,7 @@ ngx.resp = {}
 ---@param max_headers? number
 ---@param raw? boolean
 ---@return table<string, string|string[]>
----@return string|'"truncated"' error
+---@return string|"truncated" error
 function ngx.resp.get_headers(max_headers, raw) end
 
 ---@alias ngx.thread.arg boolean|number|integer|string|lightuserdata|table

--- a/library/ngx.lua
+++ b/library/ngx.lua
@@ -2744,6 +2744,33 @@ function udpsock:close() end
 ---@param time number
 function udpsock:settimeout(time) end
 
+
+--- Just like the standard `proxy_bind` directive, this api makes the outgoing connection to a upstream server originate from the specified local IP address.
+---
+--- Only IP addresses can be specified as the `address` argument.
+---
+--- Here is an example for connecting to a TCP server from the specified local IP address:
+---
+--- ```nginx
+---  location /test {
+---      content_by_lua_block {
+---          local sock = ngx.socket.udp()
+---          -- assume "192.168.1.10" is the local ip address
+---          local ok, err = sock:bind("192.168.1.10")
+---          if not ok then
+---              ngx.say("failed to bind: ", err)
+---              return
+---          end
+---          sock:close()
+---      }
+---  }
+--- ```
+---@param  address  string # must be an IP address
+---@return boolean? ok
+---@return string?  error
+function udpsock:bind(address) end
+
+
 --- Creates and returns a TCP or stream-oriented unix domain socket object (also known as one type of the "cosocket" objects). The following methods are supported on this object:
 ---
 --- * `connect`
@@ -3268,6 +3295,38 @@ function tcpsock:setkeepalive(timeout, size) end
 ---@return number? count
 ---@return string? error
 function tcpsock:getreusedtimes() end
+
+
+--- Just like the standard `proxy_bind` directive, this api makes the outgoing connection to a upstream server originate from the specified local IP address.
+---
+--- Only IP addresses can be specified as the address argument.
+---
+--- Here is an example for connecting to a TCP server from the specified local IP address:
+---
+--- ```nginx
+---  location /test {
+---      content_by_lua_block {
+---          local sock = ngx.socket.tcp()
+---          -- assume "192.168.1.10" is the local ip address
+---          local ok, err = sock:bind("192.168.1.10")
+---          if not ok then
+---              ngx.say("failed to bind")
+---              return
+---          end
+---          local ok, err = sock:connect("192.168.1.67", 80)
+---          if not ok then
+---              ngx.say("failed to connect server: ", err)
+---              return
+---          end
+---          ngx.say("successfully connected!")
+---          sock:close()
+---      }
+---  }
+--- ```
+---@param  address  string # must be an IP address
+---@return boolean? ok
+---@return string?  error
+function tcpsock:bind(address) end
 
 --- This function is a shortcut for combining `ngx.socket.tcp()` and the `connect()` method call in a single operation. It is actually implemented like this:
 ---

--- a/library/ngx.lua
+++ b/library/ngx.lua
@@ -2744,7 +2744,6 @@ function udpsock:close() end
 ---@param time number
 function udpsock:settimeout(time) end
 
-
 --- Just like the standard `proxy_bind` directive, this api makes the outgoing connection to a upstream server originate from the specified local IP address.
 ---
 --- Only IP addresses can be specified as the `address` argument.
@@ -2769,7 +2768,6 @@ function udpsock:settimeout(time) end
 ---@return boolean? ok
 ---@return string?  error
 function udpsock:bind(address) end
-
 
 --- Creates and returns a TCP or stream-oriented unix domain socket object (also known as one type of the "cosocket" objects). The following methods are supported on this object:
 ---
@@ -3295,7 +3293,6 @@ function tcpsock:setkeepalive(timeout, size) end
 ---@return number? count
 ---@return string? error
 function tcpsock:getreusedtimes() end
-
 
 --- Just like the standard `proxy_bind` directive, this api makes the outgoing connection to a upstream server originate from the specified local IP address.
 ---

--- a/library/ngx/balancer.lua
+++ b/library/ngx/balancer.lua
@@ -50,8 +50,8 @@ function balancer.set_current_peer(addr, port) end
 function balancer.set_timeouts(connect_timeout, send_timeout, read_timeout) end
 
 ---@alias ngx.balancer.failure
----| '"next"' # Failures due to bad status codes sent from the backend server. The origin's response is same though, which means the backend connection can still be reused for future requests.
----| '"failed"' Fatal errors while communicating to the backend server (like connection timeouts, connection resets, and etc). In this case, the backend connection must be aborted and cannot get reused.
+---| "next" # Failures due to bad status codes sent from the backend server. The origin's response is same though, which means the backend connection can still be reused for future requests.
+---| "failed" # Fatal errors while communicating to the backend server (like connection timeouts, connection resets, and etc). In this case, the backend connection must be aborted and cannot get reused.
 
 --- Retrieves the failure details about the previous failed attempt (if any) when
 --- the next_upstream retrying mechanism is in action. When there was indeed a

--- a/library/ngx/balancer.lua
+++ b/library/ngx/balancer.lua
@@ -1,7 +1,9 @@
 ---@meta
-local balancer = {
-	version = require("resty.core.base").version,
-}
+
+---@class ngx.balancer
+---
+---@field version string
+local balancer = {}
 
 --- Sets the peer address (host and port) for the current backend query (which
 --- may be a retry).

--- a/library/ngx/balancer.lua
+++ b/library/ngx/balancer.lua
@@ -114,4 +114,16 @@ function balancer.set_more_tries(count) end
 ---@return string? error
 function balancer.recreate_request() end
 
+--- Turn off the HTTPs or reenable the HTTPs for the upstream connection.
+---
+--- - If `on` is `true`, then the https protocol will be used to connect to the upstream server.
+--- - If `on` is `false`, then the http protocol will be used to connect to the upstream server.
+---
+--- This function was first added in the `0.1.29` version of this library.
+---
+---@param on boolean
+---@return boolean? ok
+---@return string? error
+function balancer.set_upstream_tls(on) end
+
 return balancer

--- a/library/ngx/base64.lua
+++ b/library/ngx/base64.lua
@@ -1,7 +1,9 @@
 ---@meta
-local base64 = {
-	version = require("resty.core.base").version,
-}
+
+---@class ngx.base64
+---
+---@field version string
+local base64 = {}
 
 ---Encode input using base64url rules. Returns the encoded string.
 ---@param s string

--- a/library/ngx/errlog.lua
+++ b/library/ngx/errlog.lua
@@ -1,7 +1,9 @@
 ---@meta
-local errlog = {
-	version = require("resty.core.base").version,
-}
+
+---@class ngx.errlog
+---
+---@field version string
+local errlog = {}
 
 --- Return the nginx core's error log filter level (defined via the `error_log` configuration directive in nginx.conf) as an integer value.
 ---@return ngx.log.level

--- a/library/ngx/ocsp.lua
+++ b/library/ngx/ocsp.lua
@@ -1,7 +1,9 @@
 ---@meta
-local ocsp = {
-	version = require("resty.core.base").version,
-}
+
+---@class ngx.ocsp
+---
+---@field version string
+local ocsp = {}
 
 --- Extracts the OCSP responder URL (like "http://test.com/ocsp/") from the SSL server certificate chain in the DER format.
 ---

--- a/library/ngx/pipe.lua
+++ b/library/ngx/pipe.lua
@@ -149,7 +149,7 @@ function proc:set_timeouts(write_timeout, stdout_read_timeout, stderr_read_timeo
 --- If a thread tries to wait an exited process, the return values will be `nil` and the error string "exited".
 ---
 ---@return boolean             ok
----@return '"exit"'|'"signal"' reason
+---@return "exit"|"signal" reason
 ---@return number              status
 function proc:wait() end
 
@@ -188,7 +188,7 @@ function proc:kill(signum) end
 ---
 ---It is fine to shut down the same direction of the same stream multiple times; no side effects are to be expected.
 ---
----@param direction '"stdin"'|'"stdout"'|'"stderr"'
+---@param direction "stdin"|"stdout"|"stderr"
 ---@return boolean ok
 ---@return string? error
 function proc:shutdown(direction) end

--- a/library/ngx/pipe.lua
+++ b/library/ngx/pipe.lua
@@ -1,8 +1,9 @@
 ---@meta
-local pipe = {}
-pipe._gc_ref_c_opt = "-c"
 
-pipe.version = require("resty.core.base").version
+---@class ngx.pipe
+---
+---@field version string
+local pipe = {}
 
 --- Creates and returns a new sub-process instance we can communicate with later.
 ---

--- a/library/ngx/process.lua
+++ b/library/ngx/process.lua
@@ -26,11 +26,11 @@ function process.get_master_pid() end
 function process.enable_privileged_agent(connections) end
 
 ---@alias ngx.process.type
----| '"master"'           # the NGINX master process
----| '"worker"'           # an NGINX worker process
----| '"privileged agent"' # the NGINX privileged agent process
----| '"single"'           # returned when Nginx is running in the single process mode
----| '"signaller"'        # returned when Nginx is running as a signaller process
+---| "master"           # the NGINX master process
+---| "worker"           # an NGINX worker process
+---| "privileged agent" # the NGINX privileged agent process
+---| "single"           # returned when Nginx is running in the single process mode
+---| "signaller"        # returned when Nginx is running as a signaller process
 
 --- Returns the type of the current NGINX process.
 ---

--- a/library/ngx/process.lua
+++ b/library/ngx/process.lua
@@ -1,7 +1,9 @@
 ---@meta
-local process = {
-	version = require("resty.core.base").version,
-}
+
+---@class ngx.process
+---
+---@field version string
+local process = {}
 
 --- Returns a number value for the nginx master process's process ID (or PID).
 ---

--- a/library/ngx/re.lua
+++ b/library/ngx/re.lua
@@ -1,7 +1,9 @@
 ---@meta
-local re = {}
 
-re.version = require("resty.core.base").version
+---@class ngx.re
+---
+---@field version string
+local re = {}
 
 --- Allows changing of regex settings. Currently, it can only change the `jit_stack_size` of the PCRE engine, like so:
 ---

--- a/library/ngx/re.lua
+++ b/library/ngx/re.lua
@@ -26,7 +26,7 @@ re.version = require("resty.core.base").version
 ---
 --- The `jit_stack_size` cannot be set to a value lower than PCRE's default of 32K.
 ---
----@param option string '"jit_stack_size"'
+---@param option string|"jit_stack_size"
 ---@param value any
 function re.opt(option, value) end
 

--- a/library/ngx/req.lua
+++ b/library/ngx/req.lua
@@ -1,7 +1,9 @@
 ---@meta
-local req = {}
 
-req.version = require("resty.core.base").version
+---@class ngx.req
+---
+---@field version string
+local req = {}
 
 ---This method adds the specified header and its value to the current request. It works similarly as ngx.req.set_header, with the exception that when the header already exists, the specified value(s) will be appended instead of overriden.
 ---

--- a/library/ngx/resp.lua
+++ b/library/ngx/resp.lua
@@ -1,7 +1,9 @@
 ---@meta
-local resp = {}
 
-resp.version = require("resty.core.base").version
+---@class ngx.resp
+---
+---@field version string
+local resp = {}
 
 --- This function adds specified header with corresponding value to the response of current request.
 ---

--- a/library/ngx/semaphore.lua
+++ b/library/ngx/semaphore.lua
@@ -1,11 +1,12 @@
 ---@meta
 
 ---@class ngx.semaphore
+---
+---@field version string
+---
 --- sem is the internal c handler
 ---@field sem userdata
-local semaphore = {
-	version = require("resty.core.base").version,
-}
+local semaphore = {}
 
 ---Creates and returns a new semaphore instance.
 ---
@@ -47,7 +48,7 @@ function semaphore:count() end
 ---
 ---@param  timeout? number
 ---@return boolean  ok
----@return string|"timeout"  error
+---@return string|"timeout"?  error
 function semaphore:wait(timeout) end
 
 --- Releases n (default to 1) "resources" to the semaphore instance.

--- a/library/ngx/semaphore.lua
+++ b/library/ngx/semaphore.lua
@@ -47,7 +47,7 @@ function semaphore:count() end
 ---
 ---@param  timeout? number
 ---@return boolean  ok
----@return string|'"timeout"'  error
+---@return string|"timeout"  error
 function semaphore:wait(timeout) end
 
 --- Releases n (default to 1) "resources" to the semaphore instance.

--- a/library/ngx/ssl.lua
+++ b/library/ngx/ssl.lua
@@ -1,5 +1,35 @@
 ---@meta
+
+---@class ngx.ssl
+---
+---@field version string
+---
+---@field SSL3_VERSION   ngx.ssl.SSL3_VERSION
+---@field TLS1_VERSION   ngx.ssl.TLS1_VERSION
+---@field TLS1_1_VERSION ngx.ssl.TLS1_1_VERSION
+---@field TLS1_2_VERSION ngx.ssl.TLS1_2_VERSION
+---@field TLS1_3_VERSION ngx.ssl.TLS1_3_VERSION
 local ssl = {}
+
+---@alias ngx.ssl.SSL3_VERSION   768
+---@alias ngx.ssl.TLS1_VERSION   769
+---@alias ngx.ssl.TLS1_1_VERSION 770
+---@alias ngx.ssl.TLS1_2_VERSION 771
+---@alias ngx.ssl.TLS1_3_VERSION 772
+
+---@alias ngx.ssl.tls_version.integer
+---| ngx.ssl.SSL3_VERSION
+---| ngx.ssl.TLS1_VERSION
+---| ngx.ssl.TLS1_1_VERSION
+---| ngx.ssl.TLS1_2_VERSION
+---| ngx.ssl.TLS1_3_VERSION
+
+---@alias ngx.ssl.tls_version.string
+---| "SSLv3"
+---| "TLSv1"
+---| "TLSv1.1"
+---| "TLSv1.2"
+---| "TLSv1.3"
 
 --- Sets the DER-formatted prviate key for the current SSL connection.
 ---
@@ -29,14 +59,14 @@ function ssl.parse_pem_priv_key(pem_priv_key) end
 ---
 --- Typical return values are:
 ---
----     0x0300(SSLv3)
----     0x0301(TLSv1)
----     0x0302(TLSv1.1)
----     0x0303(TLSv1.2)
----     0x0304(TLSv1.3)
+---     0x0300 (768) SSLv3
+---     0x0301 (769) TLSv1
+---     0x0302 (770) TLSv1.1
+---     0x0303 (771) TLSv1.2
+---     0x0304 (772) TLSv1.3
 ---
 --- This function can be called in any context where downstream https is used.
----@return number? version
+---@return ngx.ssl.tls_version.integer? version
 ---@return string? error
 function ssl.get_tls1_version() end
 
@@ -51,7 +81,6 @@ function ssl.get_tls1_version() end
 ---@return string? error
 function ssl.set_cert(cert_chain) end
 
-ssl.TLS1_VERSION = 769
 
 --- Sets the SSL private key opaque pointer returned by the parse_pem_priv_key function for the current SSL connection.
 ---
@@ -173,9 +202,6 @@ function ssl.raw_client_addr() end
 ---@return string? error
 function ssl.parse_pem_cert(pem_cert_chain) end
 
-ssl.version = require("resty.core.base").version
-ssl.TLS1_2_VERSION = 771
-
 --- Returns the TLS SNI (Server Name Indication) name set by the client. Returns nil when the client does not set it.
 ---
 --- In case of failures, it returns nil and a string describing the error.
@@ -199,9 +225,6 @@ function ssl.server_name() end
 ---@return number? server_port
 ---@return string? error
 function ssl.server_port() end
-
-ssl.TLS1_1_VERSION = 770
-ssl.SSL3_VERSION = 768
 
 --- Sets the DER-formatted SSL certificate chain data for the current SSL connection. Note that the DER data is directly in the Lua string argument. No external file names are supported here.
 ---
@@ -227,7 +250,7 @@ function ssl.set_der_cert(der_cert_chain) end
 ---
 --- This function can be called in any context where downstream https is used.
 ---
----@return string? version
+---@return ngx.ssl.tls_version.string? version
 ---@return string? error
 function ssl.get_tls1_version_str() end
 

--- a/library/ngx/ssl.lua
+++ b/library/ngx/ssl.lua
@@ -352,4 +352,17 @@ function ssl.export_keying_material(length, label, context) end
 ---@return string?  error
 function ssl.export_keying_material_early(length, label, context) end
 
+--- Returns the random value sent from the client to the server during the initial SSL/TLS handshake.
+---
+--- The `outlen` parameter indicates the maximum length of the client_random value returned.
+--- If the `outlen` is zero, this function returns the total length of the client_random value.
+--- If omitted, will use the value 32.
+---
+--- This function can be called in any context where downstream https is used, but in the context of [ssl_client_hello_by_lua*](https://github.com/openresty/lua-nginx-module/#ssl_client_hello_by_lua_block), it can not return the real client_random value, just a string filled with 0.
+---
+---@param  outlen?         integer
+---@return string|integer? result
+---@return string?         error
+function ssl.get_client_random(outlen) end
+
 return ssl

--- a/library/ngx/ssl.lua
+++ b/library/ngx/ssl.lua
@@ -107,9 +107,9 @@ function ssl.set_priv_key(priv_key) end
 function ssl.raw_server_addr() end
 
 ---@alias ngx.ssl.addr_type
----| '"unix"'  # a file path for the UNIX domain socket.
----| '"inet"'  # a binary IPv4 address of 4 bytes long.
----| '"inet6"' # a binary IPv6 address of 16 bytes long.
+---| "unix"  # a file path for the UNIX domain socket.
+---| "inet"  # a binary IPv4 address of 4 bytes long.
+---| "inet6" # a binary IPv6 address of 16 bytes long.
 
 --- Clears any existing SSL certificates and/or private keys set on the current SSL connection.
 ---

--- a/library/ngx/ssl.lua
+++ b/library/ngx/ssl.lua
@@ -273,4 +273,17 @@ function ssl.cert_pem_to_der(pem_cert_chain) end
 ---@return string? error
 function ssl.verify_client(ca_certs, depth) end
 
+--- Retrieves the OpenSSL `SSL*` object for the current downstream connection.
+---
+--- Returns an FFI pointer on success, or a `nil` value and a string describing the error otherwise.
+---
+--- If you need to retain the pointer beyond the current phase then you will need to use OpenSSL's `SSL_up_ref` to increase the reference count.
+--- If you do, ensure that your reference is released with `SSL_free`.
+---
+--- This function was first added in version `0.1.16`.
+---
+---@return ffi.cdata*? pointer
+---@return string?     error
+function ssl.get_req_ssl_pointer() end
+
 return ssl

--- a/library/ngx/ssl.lua
+++ b/library/ngx/ssl.lua
@@ -286,4 +286,70 @@ function ssl.verify_client(ca_certs, depth) end
 ---@return string?     error
 function ssl.get_req_ssl_pointer() end
 
+--- Return a key derived from the SSL master secret.
+---
+--- As described in RFC8446 section 7.5 this function returns key material that is derived from the SSL master secret and can be used on the application level. The returned key material is of the given length. Label is mandatory and requires a special format that is described in RFC5705 section 4. Context is optional but note that in TLSv1.2 and below a zero length context is treated differently from no context at all, and will result in different keying material being returned. In TLSv1.3 a zero length context is that same as no context at all and will result in the same keying material being returned.
+---
+--- The following code snippet shows how to derive a new key that can be used on the application level.
+---
+--- ```lua
+--- local ssl = require "ngx.ssl"
+---
+--- local key_length = 16
+--- local label = "EXPERIMENTAL my label"
+--- local context = "\x00\x01\x02\x03"
+---
+--- local key, err = ssl.export_keying_material(key_length, label, context)
+--- if not key then
+---     ngx.log(ngx.ERR, "failed to derive key ", err)
+---     return
+--- end
+---
+--- -- use key...
+---
+--- end
+--- ```
+---
+--- This function can be called in any context where downstream https is used.
+---
+---@param  length   integer
+---@param  label    string
+---@param  context? string
+---@return string?  key
+---@return string?  error
+function ssl.export_keying_material(length, label, context) end
+
+--- Returns a key derived from the SSL early exporter master secret.
+---
+--- As described in RFC8446 section 7.5 this function returns key material that is derived from the SSL early exporter master secret and can be used on the application level. The returned key material is of the given length. Label is mandatory and requires a special format that is described in RFC5705 section 4. This function is only usable with TLSv1.3, and derives keying material using the early_exporter_master_secret (as defined in the TLS 1.3 RFC). For the client, the early_exporter_master_secret is only available when the client attempts to send 0-RTT data. For the server, it is only available when the server accepts 0-RTT data.
+---
+--- The following code snippet shows how to derive a new key that can be used on the application level.
+---
+--- ```lua
+--- local ssl = require "ngx.ssl"
+---
+--- local key_length = 16
+--- local label = "EXPERIMENTAL my label"
+--- local context = "\x00\x01\x02\x03"
+---
+--- local key, err = ssl.export_keying_material_early(key_length, label, context)
+--- if not key then
+---     ngx.log(ngx.ERR, "failed to derive key ", err)
+---     return
+--- end
+---
+--- -- use key...
+---
+--- end
+--- ```
+---
+--- This function can be called in any context where downstream https TLS1.3 is used.
+---
+---@param  length   integer
+---@param  label    string
+---@param  context? string
+---@return string?  key
+---@return string?  error
+function ssl.export_keying_material_early(length, label, context) end
+
 return ssl

--- a/library/ngx/ssl.lua
+++ b/library/ngx/ssl.lua
@@ -55,6 +55,16 @@ function ssl.set_der_priv_key(der_priv_key) end
 ---@return string? error
 function ssl.parse_pem_priv_key(pem_priv_key) end
 
+--- Converts the DER-formatted SSL private key data into an opaque cdata pointer (for later uses in the `set_priv_key()` function, for example).
+---
+--- In case of failures, returns `nil` and a string describing the error.
+---
+--- This function can be called in any context.
+---@param der_priv_key string
+---@return ffi.cdata*? priv_key
+---@return string? error
+function ssl.parse_der_priv_key(der_priv_key) end
+
 --- Returns the TLS 1.x version number used by the current SSL connection. Returns nil and a string describing the error otherwise.
 ---
 --- Typical return values are:
@@ -70,7 +80,7 @@ function ssl.parse_pem_priv_key(pem_priv_key) end
 ---@return string? error
 function ssl.get_tls1_version() end
 
---- Sets the SSL certificate chain opaque pointer returned by the parse_pem_cert function for the current SSL connection.
+--- Sets the SSL certificate chain opaque pointer returned by the `parse_pem_cert()` or `parse_der_cert()` functions for the current SSL connection.
 ---
 --- Returns true on success, or a nil value and a string describing the error otherwise.
 ---
@@ -81,8 +91,7 @@ function ssl.get_tls1_version() end
 ---@return string? error
 function ssl.set_cert(cert_chain) end
 
-
---- Sets the SSL private key opaque pointer returned by the parse_pem_priv_key function for the current SSL connection.
+--- Sets the SSL private key opaque pointer returned by the `parse_pem_priv_key()` or `parse_der_priv_key()` functions for the current SSL connection.
 ---
 --- Returns true on success, or a nil value and a string describing the error otherwise.
 ---
@@ -201,6 +210,18 @@ function ssl.raw_client_addr() end
 ---@return ffi.cdata*? cert_chain
 ---@return string? error
 function ssl.parse_pem_cert(pem_cert_chain) end
+
+--- Converts the DER-formated SSL certificate chain data into an opaque cdata pointer (for later usese in the `set_cert()` function, for example).
+---
+--- In case of failures, returns `nil` and a string describing the error.
+---
+--- You can always use libraries like [lua-resty-lrucache](https://github.com/openresty/lua-resty-lrucache#readme) to cache the cdata result.
+---
+--- This function can be called in any context.
+---@param der_cert_chain string
+---@return ffi.cdata*? cert_chain
+---@return string? error
+function ssl.parse_der_cert(der_cert_chain) end
 
 --- Returns the TLS SNI (Server Name Indication) name set by the client. Returns nil when the client does not set it.
 ---

--- a/library/ngx/ssl/clienthello.lua
+++ b/library/ngx/ssl/clienthello.lua
@@ -1,7 +1,9 @@
 ---@meta
-local clienthello = {}
 
-clienthello.version = require("resty.core.base").version
+---@class ngx.ssl.clienthello
+---
+---@field version string
+local clienthello = {}
 
 ---Returns the TLS SNI (Server Name Indication) name set by the client.
 ---

--- a/library/ngx/ssl/clienthello.lua
+++ b/library/ngx/ssl/clienthello.lua
@@ -93,9 +93,23 @@ function clienthello.get_client_hello_ext(ext_type) end
 ---  ssl_clt.set_protocols({"TLSv1.1", "TLSv1.2", "TLSv1.3"})`
 --- ```
 ---
----@param protocols string[]
+---@param protocols ngx.ssl.tls_version.string[]
 ---@return boolean ok
 ---@return string? error
 function clienthello.set_protocols(protocols) end
+
+--- Returns the table of ssl hello supported versions set by the client.
+---
+--- Return `nil` when then the extension does not exist.
+---
+--- In case of errors, it returns `nil` and a string describing the error.
+---
+--- Note that the types is gotten from the raw extensions of the client hello message associated with the current downstream SSL connection.
+---
+--- This function can only be called in the context of `ssl_client_hello_by_lua*`.
+---
+---@return ngx.ssl.tls_version.string[]|nil versions
+---@return string? error
+function clienthello.get_supported_versions() end
 
 return clienthello

--- a/library/ngx/ssl/session.lua
+++ b/library/ngx/ssl/session.lua
@@ -1,7 +1,9 @@
 ---@meta
-local session = {}
 
-session.version = require("resty.core.base").version
+---@class ngx.ssl.session
+---
+---@field version string
+local session = {}
 
 --- Sets the serialized SSL session provided as the argument to the current SSL connection.
 --- If the SSL session is successfully set, the current SSL connection can resume the session

--- a/library/ngx/upstream.lua
+++ b/library/ngx/upstream.lua
@@ -1,9 +1,15 @@
 ---@meta
+
+---@class ngx.upstream
+---
+---@field version string
 local upstream = {}
+
 function upstream.get_backup_peers() end
 function upstream.get_servers() end
 function upstream.current_upstream_name() end
 function upstream.get_primary_peers() end
 function upstream.set_peer_down() end
 function upstream.get_upstreams() end
+
 return upstream

--- a/library/resty/aes.lua
+++ b/library/resty/aes.lua
@@ -3,14 +3,14 @@
 local aes = {}
 
 ---@alias resty.aes.cipher.name
----| '"ecb"'
----| '"cbc"'
----| '"cfb1"'
----| '"cfb128"'
----| '"cfb8"'
----| '"ctr"
----| '"gcm"'
----| '"ofb"'
+---| "ecb"
+---| "cbc"
+---| "cfb1"
+---| "cfb128"
+---| "cfb8"
+---| "ctr"
+---| "gcm"
+---| "ofb"
 
 ---@alias resty.aes.cipher.size '128'|'192'|'256'
 

--- a/library/resty/aes.lua
+++ b/library/resty/aes.lua
@@ -60,15 +60,17 @@ local aes_ctx = {}
 ---
 ---@param  s       string
 ---@param  tag?    string
+---@param  aad?    string # Additional Authenticated Data
 ---@return string? decrypted
 ---@return string? error
-function aes_ctx:decrypt(s, tag) end
+function aes_ctx:decrypt(s, tag, aad) end
 
 --- Encrypt a string.
 ---
 ---@param  s       string
+---@param  aad?    string # Additional Authenticated Data
 ---@return string? encrypted
 ---@return string? error
-function aes_ctx:encrypt(s) end
+function aes_ctx:encrypt(s, aad) end
 
 return aes

--- a/library/resty/core.lua
+++ b/library/resty/core.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core = {}
-resty_core.version = require("resty.core.base").version
-return resty_core
+
+---@class resty.core
+---
+---@field version string
+local core = {}
+
+return core

--- a/library/resty/core/base.lua
+++ b/library/resty/core/base.lua
@@ -1,51 +1,54 @@
 ---@meta
-local resty_core_base = {}
+
+---@class resty.core.base
+---
+---@field version string
+---
+---@field FFI_OK          0
+---@field FFI_NO_REQ_CTX  -100
+---@field FFI_BAD_CONTEXT -101
+---@field FFI_ERROR       -1
+---@field FFI_AGAIN       -2
+---@field FFI_BUSY        -3
+---@field FFI_DONE        -4
+---@field FFI_DECLINED    -5
+---@field FFI_ABORT       -6
+local base = {}
 
 ---@param ... string
-function resty_core_base.allows_subsystem(...) end
+function base.allows_subsystem(...) end
 
 ---@param t table
-function resty_core_base.clear_tab(t) end
+function base.clear_tab(t) end
 
 ---@return userdata
-function resty_core_base.get_errmsg_ptr() end
+function base.get_errmsg_ptr() end
 
 ---@return userdata
-function resty_core_base.get_request() end
+function base.get_request() end
 
 ---@return userdata
-function resty_core_base.get_size_ptr() end
+function base.get_size_ptr() end
 
 ---@param size number
 ---@param must_alloc? boolean
 ---@return userdata
-function resty_core_base.get_string_buf(size, must_alloc) end
+function base.get_string_buf(size, must_alloc) end
 
 ---@return number
-function resty_core_base.get_string_buf_size() end
+function base.get_string_buf_size() end
 
 ---@param narr number
 ---@param nrec number
 ---@return table
-function resty_core_base.new_tab(narr, nrec) end
+function base.new_tab(narr, nrec) end
 
 ---@param tb table
 ---@param key any
 ---@return any
-function resty_core_base.ref_in_table(tb, key) end
+function base.ref_in_table(tb, key) end
 
 ---@param size number
-function resty_core_base.set_string_buf_size(size) end
+function base.set_string_buf_size(size) end
 
-resty_core_base.FFI_OK = 0
-resty_core_base.FFI_NO_REQ_CTX = -100
-resty_core_base.FFI_BAD_CONTEXT = -101
-resty_core_base.FFI_ERROR = -1
-resty_core_base.FFI_AGAIN = -2
-resty_core_base.FFI_BUSY = -3
-resty_core_base.FFI_DONE = -4
-resty_core_base.FFI_DECLINED = -5
-
-resty_core_base.version = "0.1.23"
-
-return resty_core_base
+return base

--- a/library/resty/core/base64.lua
+++ b/library/resty/core/base64.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_base64 = {}
-resty_core_base64.version = require("resty.core.base").version
-return resty_core_base64
+
+---@class resty.core.base64
+---
+---@field version string
+local base64 = {}
+
+return base64

--- a/library/resty/core/ctx.lua
+++ b/library/resty/core/ctx.lua
@@ -1,9 +1,12 @@
 ---@meta
-local resty_core_ctx = {}
-resty_core_ctx._VERSION = require("resty.core.base").version
+
+---@class resty.core.ctx
+---
+---@field _VERSION string
+local ctx = {}
 
 ---@param ctx? table
 ---@return table
-function resty_core_ctx.get_ctx_table(ctx) end
+function ctx.get_ctx_table(ctx) end
 
-return resty_core_ctx
+return ctx

--- a/library/resty/core/exit.lua
+++ b/library/resty/core/exit.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_exit = {}
-resty_core_exit.version = require("resty.core.base").version
-return resty_core_exit
+
+---@class resty.core.exit
+---
+---@field version string
+local exit = {}
+
+return exit

--- a/library/resty/core/hash.lua
+++ b/library/resty/core/hash.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_hash = {}
-resty_core_hash.version = require("resty.core.base").version
-return resty_core_hash
+
+---@class resty.core.hash
+---
+---@field version string
+local hash = {}
+
+return hash

--- a/library/resty/core/misc.lua
+++ b/library/resty/core/misc.lua
@@ -1,6 +1,11 @@
 ---@meta
-local resty_core_misc = {}
-function resty_core_misc.register_ngx_magic_key_getter() end
-function resty_core_misc.register_ngx_magic_key_setter() end
-resty_core_misc._VERSION = require("resty.core.base").version
-return resty_core_misc
+
+---@class resty.core.misc
+---
+---@field _VERSION string
+local misc = {}
+
+function misc.register_ngx_magic_key_getter() end
+function misc.register_ngx_magic_key_setter() end
+
+return misc

--- a/library/resty/core/ndk.lua
+++ b/library/resty/core/ndk.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_ndk = {}
-resty_core_ndk.version = require("resty.core.base").version
-return resty_core_ndk
+
+---@class resty.core.ndk
+---
+---@field version string
+local ndk = {}
+
+return ndk

--- a/library/resty/core/phase.lua
+++ b/library/resty/core/phase.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_phase = {}
-resty_core_phase.version = require("resty.core.base").version
-return resty_core_phase
+
+---@class resty.core.phase
+---
+---@field version string
+local phase = {}
+
+return phase

--- a/library/resty/core/regex.lua
+++ b/library/resty/core/regex.lua
@@ -1,6 +1,8 @@
 ---@meta
 
 ---@class resty.core.regex
+---
+---@field version string
 ---@field no_pcre boolean
 local regex = {}
 

--- a/library/resty/core/request.lua
+++ b/library/resty/core/request.lua
@@ -1,5 +1,8 @@
 ---@meta
-local resty_core_request = {}
-resty_core_request.version = require("resty.core.base").version
-function resty_core_request.set_req_header(name, value, override) end
-return resty_core_request
+
+---@class resty.core.request
+---
+---@field version string
+local request = {}
+
+return request

--- a/library/resty/core/response.lua
+++ b/library/resty/core/response.lua
@@ -1,5 +1,14 @@
 ---@meta
-local resty_core_response = {}
-function resty_core_response.set_resp_header() end
-resty_core_response.version = require("resty.core.base").version
-return resty_core_response
+
+---@class resty.core.response
+---
+---@field version string
+local response = {}
+
+---@param tb           any
+---@param key          string
+---@param value?       string|string[]
+---@param no_override? boolean
+function response.set_resp_header(tb, key, value, no_override) end
+
+return response

--- a/library/resty/core/shdict.lua
+++ b/library/resty/core/shdict.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_shdict = {}
-resty_core_shdict.version = require("resty.core.base").version
-return resty_core_shdict
+
+---@class resty.core.shdict
+---
+---@field version string
+local shdict = {}
+
+return shdict

--- a/library/resty/core/time.lua
+++ b/library/resty/core/time.lua
@@ -1,4 +1,27 @@
 ---@meta
-local resty_core_time = {}
-resty_core_time.version = require("resty.core.base").version
-return resty_core_time
+
+---@class resty.core.time
+---
+---@field version string
+local time = {}
+
+--- Returns the elapsed time in milliseconds from the machine boot for the current time stamp from the Nginx cached time (no syscall involved unlike Lua's date library).
+---
+--- ```lua
+--- local cur_msec = require "resty.core.time".monotonic_msec
+--- ngx.say(cur_msec())
+--- ```
+---@return number
+function time.monotonic_msec() end
+
+--- Returns a floating-point number for the elapsed time in seconds (including milliseconds as the decimal part) from the machine boot for the current time stamp from the Nginx cached time (no syscall involved unlike Lua's date library).
+---
+--- ```lua
+--- local cur_time = require "resty.core.time".monotonic_time
+--- ngx.say(cur_time())
+--- ```
+---
+---@return number
+function time.monotonic_time() end
+
+return time

--- a/library/resty/core/uri.lua
+++ b/library/resty/core/uri.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_uri = {}
-resty_core_uri.version = require("resty.core.base").version
-return resty_core_uri
+
+---@class resty.core.uri
+---
+---@field version string
+local uri = {}
+
+return uri

--- a/library/resty/core/utils.lua
+++ b/library/resty/core/utils.lua
@@ -1,10 +1,14 @@
 ---@meta
-local resty_core_utils = {}
+
+---@class resty.core.utils
+---
+---@field version string
+local utils = {}
 
 ---@param str string
 ---@param find string
 ---@param replace string
 ---@return string
-function resty_core_utils.str_replace_char(str, find, replace) end
-resty_core_utils.version = require("resty.core.base").version
-return resty_core_utils
+function utils.str_replace_char(str, find, replace) end
+
+return utils

--- a/library/resty/core/var.lua
+++ b/library/resty/core/var.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_var = {}
-resty_core_var.version = require("resty.core.base").version
-return resty_core_var
+
+---@class resty.core.var
+---
+---@field version string
+local var = {}
+
+return var

--- a/library/resty/core/worker.lua
+++ b/library/resty/core/worker.lua
@@ -1,4 +1,8 @@
 ---@meta
-local resty_core_worker = {}
-resty_core_worker._VERSION = require("resty.core.base").version
-return resty_core_worker
+
+---@class resty.core.worker
+---
+---@field version string
+local worker = {}
+
+return worker

--- a/library/resty/dns/resolver.lua
+++ b/library/resty/dns/resolver.lua
@@ -352,6 +352,9 @@ function resolver:reverse_query(addr) end
 ---@param timeout number # timeout in milliseconds
 function resolver:set_timeout(timeout) end
 
+--- Destroy the resolver object by releasing all the internal occupied resources.
+function resolver:destroy() end
+
 --- Compresses the successive 16-bit zero groups in the textual format of the IPv6 address.
 ---
 --- For example, the following will yield `FF01::101` in the new_addr return value:

--- a/library/resty/dns/resolver.lua
+++ b/library/resty/dns/resolver.lua
@@ -192,7 +192,7 @@ function resolver:new(opts) end
 ---@param qname string
 ---@param opts? resty.dns.resolver.query.opts
 ---@param tries? string[]
----@return resty.dns.resolver.query.answer[] results
+---@return resty.dns.resolver.answer[] results
 ---@return string? error
 ---@return string[]? tries
 function resolver:query(qname, opts, tries) end
@@ -305,19 +305,6 @@ function resolver:query(qname, opts, tries) end
 ---@field expire   integer # SOA expire
 ---@field minimum  integer # SOA minimum
 
----@alias resty.dns.resolver.query.answer
----| resty.dns.resolver.answer
----| resty.dns.resolver.answer.A
----| resty.dns.resolver.answer.AAAA
----| resty.dns.resolver.answer.CNAME
----| resty.dns.resolver.answer.MX
----| resty.dns.resolver.answer.NS
----| resty.dns.resolver.answer.PTR
----| resty.dns.resolver.answer.SOA
----| resty.dns.resolver.answer.SPF
----| resty.dns.resolver.answer.SRV
----| resty.dns.resolver.answer.TXT
-
 --- Options for `resty.dns.resolver:query()`
 ---
 ---@class resty.dns.resolver.query.opts : table
@@ -334,7 +321,7 @@ function resolver:query(qname, opts, tries) end
 ---
 ---@param qname string
 ---@param opts? resty.dns.resolver.query.opts
----@return resty.dns.resolver.query.answer[] results
+---@return resty.dns.resolver.answer[] results
 ---@return string? error
 function resolver:tcp_query(qname, opts) end
 

--- a/library/resty/random.lua
+++ b/library/resty/random.lua
@@ -2,8 +2,8 @@
 local random = {}
 
 --- Generate random bytes.
----@param len integer
----@param strong boolean
+---@param len     integer
+---@param strong? boolean # default: true
 ---@return string
 function random.bytes(len, strong) end
 

--- a/library/resty/shell.lua
+++ b/library/resty/shell.lua
@@ -53,7 +53,7 @@ local shell = {
 ---@return boolean ok
 ---@return string? stdout
 ---@return string? stderr
----@return string|'"exit"'|'"signal"' reason
+---@return string|"exit"|"signal" reason
 ---@return number? status
 function shell.run(cmd, stdin, timeout, max_size) end
 

--- a/library/resty/shell.lua
+++ b/library/resty/shell.lua
@@ -1,8 +1,9 @@
 ---@meta
 
-local shell = {
-	version = 0.03,
-}
+---@class resty.shell
+---
+---@field version number
+local shell = {}
 
 --- Runs a shell command, `cmd`, with an optional stdin.
 ---

--- a/library/resty/signal.lua
+++ b/library/resty/signal.lua
@@ -1,8 +1,9 @@
 ---@meta
 
-local signal = {
-	version = 0.03,
-}
+---@class resty.signal
+---
+---@field version number
+local signal = {}
 
 ---@alias resty.signal.name
 ---| "NONE"   # SIG_NONE

--- a/library/resty/upload.lua
+++ b/library/resty/upload.lua
@@ -1,7 +1,30 @@
 ---@meta
-resty_upload = {}
-function resty_upload.read(self) end
-function resty_upload.set_timeout(self, timeout) end
-resty_upload._VERSION = "0.10"
-function resty_upload.new(self, chunk_size, max_line_size) end
-return resty_upload
+
+---@class resty.upload
+---
+---@field _VERSION string
+local upload = {}
+
+---@param chunk_size?    integer  # default: 4096
+---@param max_line_size? integer  # default: 512
+---@param preserve_body? boolean  # default: false
+---
+---@return resty.upload? upload
+---@return string?       error
+function upload:new(chunk_size, max_line_size, preserve_body) end
+
+---@alias resty.upload.chunk_type
+---| "header"
+---| "body"
+---| "part_end"
+---| "eof"
+
+---@return resty.upload.chunk_type? type
+---@return string?                  chunk
+---@return string?                  error
+function upload:read() end
+
+---@param timeout number # milliseconds
+function upload:set_timeout(timeout) end
+
+return upload

--- a/library/resty/upstream/healthcheck.lua
+++ b/library/resty/upstream/healthcheck.lua
@@ -1,6 +1,77 @@
 ---@meta
-resty_upstream_healthcheck = {}
-function resty_upstream_healthcheck.status_page() end
-resty_upstream_healthcheck._VERSION = "0.05"
-function resty_upstream_healthcheck.spawn_checker(opts) end
-return resty_upstream_healthcheck
+
+---@class resty.upstream.healthcheck
+---
+---@field _VERSION string
+local healthcheck = {}
+
+--- Generates a detailed status report for all the upstreams defined in the current NGINX server.
+---
+--- One typical output is
+---
+--- ```
+--- Upstream foo.com
+---     Primary Peers
+---         127.0.0.1:12354 UP
+---         127.0.0.1:12355 DOWN
+---     Backup Peers
+---         127.0.0.1:12356 UP
+---
+--- Upstream bar.com
+---     Primary Peers
+---         127.0.0.1:12354 UP
+---         127.0.0.1:12355 DOWN
+---         127.0.0.1:12357 DOWN
+---     Backup Peers
+---         127.0.0.1:12356 UP
+--- ```
+---
+--- If an upstream has no health checkers, then it will be marked by (NO checkers), as in
+---
+--- ```
+--- Upstream foo.com (NO checkers)
+---     Primary Peers
+---         127.0.0.1:12354 UP
+---         127.0.0.1:12355 UP
+---     Backup Peers
+---         127.0.0.1:12356 UP
+--- ```
+---
+--- If you indeed have spawned a healthchecker in `init_worker_by_lua*`, then you should really check out the NGINX error log file to see if there is any fatal errors aborting the healthchecker threads.
+---
+---@return string status
+function healthcheck.status_page() end
+
+---@return string
+function healthcheck.prometheus_status_page() end
+
+---@class resty.upstream.healthcheck.spawn.opts
+---
+---@field shm             string
+---@field upstream        string
+---@field type            "http"|"https"
+---@field http_req        string
+---@field port?           integer
+---@field timeout?        integer # milliseconds
+---@field interval?       number  # milliseconds
+---@field valid_statuses? integer[]
+---@field concurrency?    integer
+---@field fall?           integer
+---@field rise?           integer
+---@field ssl_verify?     boolean
+---@field host?           string
+
+--- Spawns background timer-based "light threads" to perform periodic healthchecks on the specified NGINX upstream group with the specified shm storage.
+---
+--- The healthchecker does not need any client traffic to function. The checks are performed actively and periodically.
+---
+--- This method call is asynchronous and returns immediately.
+---
+--- Returns true on success, or nil and a string describing an error otherwise.
+---
+---@param opts resty.upstream.healthcheck.spawn.opts
+---@return boolean? ok
+---@return string? error
+function healthcheck.spawn_checker(opts) end
+
+return healthcheck

--- a/library/resty/websocket/client.lua
+++ b/library/resty/websocket/client.lua
@@ -51,12 +51,70 @@ function client:set_keepalive(max_idle_timeout, pool_size) end
 ---@return string? error
 function client:close() end
 
+--- Specifies all the subprotocols used for the current WebSocket session. This can be a Lua table holding all the subprotocol names or just a single Lua string.
+---
+---@alias resty.websocket.client.connect.opts.protocols string|string[]
+
+--- Specifies the value of the `Origin` request header.
+---@alias resty.websocket.client.connect.opts.origin string
+
+--- Specifies a custom name for the connection pool being used. If omitted, then the connection pool name will be generated from the string template `<host>:<port>`.
+---@alias resty.websocket.client.connect.opts.pool string
+
+--- Specify the size of the connection pool.
+---
+--- If omitted and no backlog option was provided, no pool will be created. If omitted but backlog was provided, the pool will be created with a default size equal to the value of the `lua_socket_pool_size` directive. The connection pool holds up to `pool_size` alive connections ready to be reused by subsequent calls to connect, but note that there is no upper limit to the total number of opened connections outside of the pool. If you need to restrict the total number of opened connections, specify the `backlog` option. When the connection pool would exceed its size limit, the least recently used (kept-alive) connection already in the pool will be closed to make room for the current connection. Note that the cosocket connection pool is per Nginx worker process rather than per Nginx server instance, so the size limit specified here also applies to every single Nginx worker process. Also note that the size of the connection pool cannot be changed once it has been created. This option was first introduced in the v0.10.14 release.
+---@alias resty.websocket.client.connect.opts.pool_size integer
+
+--- If specified, this module will limit the total number of opened connections for this pool. No more connections than pool_size can be opened for this pool at any time. If the connection pool is full, subsequent connect operations will be queued into a queue equal to this option's value (the "backlog" queue). If the number of queued connect operations is equal to backlog, subsequent connect operations will fail and return nil plus the error string "too many waiting connect operations". The queued connect operations will be resumed once the number of connections in the pool is less than pool_size. The queued connect operation will abort once they have been queued for more than connect_timeout, controlled by settimeouts, and will return nil plus the error string "timeout". This option was first introduced in the v0.10.14 release.
+---
+---@alias resty.websocket.client.connect.opts.backlog integer
+
+--- Specifies whether to perform SSL certificate verification during the SSL handshake if the wss:// scheme is used.
+---
+---@alias resty.websocket.client.connect.opts.ssl_verify boolean
+
+--- Specifies custom headers to be sent in the handshake request. This must be an array-like table of strings.
+---
+--- Example:
+---
+--- ```lua
+---   local headers = {
+---     "X-My-Header: value",
+---     "X-My-Other-Header: other value",
+---   }
+--- ```
+---
+---@alias resty.websocket.client.connect.opts.headers string[]
+
+--- Specifies the value of the `Host` header sent in the handshake request. If not provided, the Host header will be derived from the hostname/address and port in the connection URI.
+---@alias resty.websocket.client.connect.opts.host string
+
+--- Specifies the server name (SNI) to use when performing the TLS handshake with the server. If not provided, the `host` value or the `<host/addr>:<port>` from the connection URI will be used.
+---@alias resty.websocket.client.connect.opts.server_name string
+
+--- Specifies the value of the `Sec-WebSocket-Key` header in the handshake request. The value should be a base64-encoded, 16 byte string conforming to the client handshake requirements of the WebSocket RFC. If not provided, a key is randomly generated.
+---@alias resty.websocket.client.connect.opts.key string
+
+--- Specifies a client certificate chain cdata object that will be used while TLS handshaking with remote server. These objects can be created using `ngx.ssl.parse_pem_cert()` function provided by lua-resty-core. Note that specifying the `client_cert` option requires corresponding `client_priv_key` be provided too.
+---@alias resty.websocket.client.connect.opts.client_cert ffi.cdata*
+
+--- Specifies a private key corresponds to the `client_cert` option. These objects can be created using `ngx.ssl.parse_pem_priv_key()` function provided by lua-resty-core.
+---@alias resty.websocket.client.connect.opts.client_priv_key ffi.cdata*
+
 ---@class resty.websocket.client.connect.opts : table
 ---
----@field protocols  string|string[]  subprotocol(s) used for the current WebSocket session
----@field origin     string           the value of the Origin request header
----@field pool       string           custom name for the connection pool being used. If omitted, then the connection pool name will be generated from the string template <host>:<port>.
----@field ssl_verify boolean          whether to perform SSL certificate verification during the SSL handshake if the wss:// scheme is used.
----@field headers    string[]         custom headers to be sent in the handshake request. The table is expected to contain strings in the format {"a-header: a header value", "another-header: another header value"}.
+---@field protocols?           resty.websocket.client.connect.opts.protocols
+---@field origin?              resty.websocket.client.connect.opts.origin
+---@field pool?                resty.websocket.client.connect.opts.pool
+---@field pool_size?           resty.websocket.client.connect.opts.pool_size
+---@field backlog?             resty.websocket.client.connect.opts.backlog
+---@field ssl_verify?          resty.websocket.client.connect.opts.ssl_verify
+---@field headers?             resty.websocket.client.connect.opts.headers
+---@field host?                resty.websocket.client.connect.opts.host
+---@field server_name?         resty.websocket.client.connect.opts.server_name
+---@field key?                 resty.websocket.client.connect.opts.key
+---@field client_cert?         resty.websocket.client.connect.opts.client_cert
+---@field client_priv_key?     resty.websocket.client.connect.opts.client_priv_key
 
 return client

--- a/library/resty/websocket/client.lua
+++ b/library/resty/websocket/client.lua
@@ -28,10 +28,17 @@ function client:new(opts) end
 ---this method will always look up the connection pool for matched idle
 ---connections created by previous calls of this method.
 ---
+---The third return value of this method contains the raw, plain-text response 
+---(status line and headers) to the handshake request. This allows the caller to
+---perform additional validation and/or extract the response headers. When the 
+---connection is reused and no handshake request is sent, the string 
+---"connection reused" is returned in lieu of the response.
+---
 ---@param  uri     string
 ---@param  opts?   resty.websocket.client.connect.opts
 ---@return boolean ok
 ---@return string? error
+---@return string? response
 function client:connect(uri, opts) end
 
 --- Puts the current WebSocket connection immediately into the ngx_lua cosocket connection pool.

--- a/library/resty/websocket/client.lua
+++ b/library/resty/websocket/client.lua
@@ -3,7 +3,12 @@
 ---@class resty.websocket.client : resty.websocket
 ---
 ---@field _VERSION string
+---
+---@field send_unmasked boolean
 local client = {}
+
+---@class resty.websocket.client.new.opts : resty.websocket.new.opts
+---@field send_unmasked? boolean # send unmasked WebSocket frames. Default: `false`.
 
 ---Instantiates a WebSocket client object.
 ---
@@ -11,7 +16,7 @@ local client = {}
 ---
 ---An optional options table can be specified.
 ---
----@param  opts?                   resty.websocket.new.opts
+---@param  opts?                   resty.websocket.client.new.opts
 ---@return resty.websocket.client? client
 ---@return string?                 error
 function client:new(opts) end

--- a/library/resty/websocket/client.lua
+++ b/library/resty/websocket/client.lua
@@ -1,9 +1,9 @@
 ---@meta
 
 ---@class resty.websocket.client : resty.websocket
-local client = {
-	_VERSION = "0.09",
-}
+---
+---@field _VERSION string
+local client = {}
 
 ---Instantiates a WebSocket client object.
 ---

--- a/library/resty/websocket/client.lua
+++ b/library/resty/websocket/client.lua
@@ -23,7 +23,7 @@ function client:new(opts) end
 ---this method will always look up the connection pool for matched idle
 ---connections created by previous calls of this method.
 ---
----@param  url     string
+---@param  uri     string
 ---@param  opts?   resty.websocket.client.connect.opts
 ---@return boolean ok
 ---@return string? error

--- a/library/resty/websocket/client.lua
+++ b/library/resty/websocket/client.lua
@@ -28,10 +28,10 @@ function client:new(opts) end
 ---this method will always look up the connection pool for matched idle
 ---connections created by previous calls of this method.
 ---
----The third return value of this method contains the raw, plain-text response 
+---The third return value of this method contains the raw, plain-text response
 ---(status line and headers) to the handshake request. This allows the caller to
----perform additional validation and/or extract the response headers. When the 
----connection is reused and no handshake request is sent, the string 
+---perform additional validation and/or extract the response headers. When the
+---connection is reused and no handshake request is sent, the string
 ---"connection reused" is returned in lieu of the response.
 ---
 ---@param  uri     string

--- a/library/resty/websocket/protocol.lua
+++ b/library/resty/websocket/protocol.lua
@@ -133,12 +133,12 @@ function websocket:recv_frame() end
 ---| '0xa' # pong
 
 ---@alias resty.websocket.protocol.type
----| '"continuation"'
----| '"text"'
----| '"binary"'
----| '"close"'
----| '"ping"'
----| '"pong"'
+---| "continuation"
+---| "text"
+---| "binary"
+---| "close"
+---| "ping"
+---| "pong"
 
 --- Builds a raw WebSocket frame.
 ---@param  fin         boolean

--- a/library/resty/websocket/protocol.lua
+++ b/library/resty/websocket/protocol.lua
@@ -9,7 +9,7 @@ local protocol = {}
 --- https://github.com/openresty/lua-resty-websocket
 ---
 ---@class resty.websocket : table
----@field sock            tcpsock
+---@field sock            ngx.socket.tcp
 ---@field fatal           boolean
 ---@field max_payload_len number
 ---@field send_masked     boolean
@@ -150,19 +150,19 @@ function websocket:recv_frame() end
 function protocol.build_frame(fin, opcode, payload_len, payload, masking) end
 
 --- Sends a raw WebSocket frame.
----@param  sock            tcpsock
+---@param  sock            ngx.socket.tcp
 ---@param  fin             boolean
 ---@param  opcode          resty.websocket.protocol.opcode
 ---@param  payload         string
----@param  max_payload_len interger
+---@param  max_payload_len integer
 ---@param  masking         boolean
----@return bytes?          number
+---@return number?         bytes
 ---@return string?         error
 function protocol.send_frame(sock, fin, opcode, payload, max_payload_len, masking) end
 
 --- Receives a WebSocket frame from the wire.
----@param  sock                           tcpsock
----@param  max_payload_len                interger
+---@param  sock                           ngx.socket.tcp
+---@param  max_payload_len                integer
 ---@param  force_masking                  boolean
 ---@return string?                        data
 ---@return resty.websocket.protocol.type? typ

--- a/library/resty/websocket/protocol.lua
+++ b/library/resty/websocket/protocol.lua
@@ -5,14 +5,14 @@
 ---@field _VERSION string
 local protocol = {}
 
---- websocket object
+--- WebSocket object
 --- https://github.com/openresty/lua-resty-websocket
 ---
 ---@class resty.websocket : table
 ---@field sock            ngx.socket.tcp
 ---@field fatal           boolean
----@field max_payload_len number
----@field send_masked     boolean
+---@field max_send_len    number
+---@field max_recv_len    number
 local websocket = {}
 
 ---@param ms integer sets the timeout delay (in milliseconds) for the network-related operations
@@ -84,7 +84,7 @@ function websocket:send_close(code, msg) end
 ---
 ---In case of errors, returns nil and a string describing the error.
 ---
----To control the maximal payload length allowed, you can pass the max_payload_len option to the new constructor.
+---To control the maximal payload length allowed, you can pass the `max_send_len` or `max_payload_len` option to the `new` constructor.
 ---
 ---To control whether to send masked frames, you can pass true to the send_masked option in the new constructor method. By default, unmasked frames are sent.
 ---@param  fin      boolean
@@ -97,6 +97,8 @@ function websocket:send_frame(fin, opcode, payload) end
 ---Receives a WebSocket frame from the wire.
 ---
 ---In case of an error, returns two nil values and a string describing the error.
+---
+---To control the maximal payload length allowed, you can pass the `max_recv_len` or `max_payload_len` option to the `new` constructor.
 ---
 ---The second return value is always the frame type, which could be one of continuation, text, binary, close, ping, pong, or nil (for unknown types).
 ---
@@ -114,11 +116,12 @@ function websocket:send_frame(fin, opcode, payload) end
 function websocket:recv_frame() end
 
 ---@class resty.websocket.new.opts : table
----@field max_payload_len  integer  maximal length of payload allowed when sending and receiving WebSocket frames
----@field send_masked      boolean  whether to send out masked WebSocket frames
----@field timeout          integer  network timeout threshold in milliseconds
+---@field max_payload_len?  integer  maximal length of payload allowed when sending and receiving WebSocket frames
+---@field max_recv_len?     integer  maximal length of payload allowed when receiving WebSocket frames. Defaults to the value of `max_payload_len`.
+---@field max_send_len?     integer  maximal length of payload allowed when sending WebSocket frames. Defaults to the value of `max_payload_len`.
+---@field timeout?          integer  network timeout threshold in milliseconds
 
---- Websocket op code
+--- WebSocket op code
 ---
 --- Defines the interpretation of the payload data.
 ---

--- a/library/resty/websocket/protocol.lua
+++ b/library/resty/websocket/protocol.lua
@@ -1,9 +1,9 @@
 ---@meta
 
 ---@class resty.websocket.protocol
-local protocol = {
-	_VERSION = "0.09",
-}
+---
+---@field _VERSION string
+local protocol = {}
 
 --- websocket object
 --- https://github.com/openresty/lua-resty-websocket

--- a/library/resty/websocket/server.lua
+++ b/library/resty/websocket/server.lua
@@ -3,14 +3,25 @@
 ---@class resty.websocket.server : resty.websocket
 ---
 ---@field _VERSION string
+---
+---@field send_masked boolean
 local server = {}
+
+---@class resty.websocket.server.new.opts : resty.websocket.new.opts
+---@field send_masked? boolean  # send masked WebSocket frames. Default: `false`.
 
 ---Performs the websocket handshake process on the server side and returns a WebSocket server object.
 ---
 ---In case of error, it returns nil and a string describing the error.
----@param  opts?                   resty.websocket.new.opts
+---@param  opts?                   resty.websocket.server.new.opts
 ---@return resty.websocket.server? server
 ---@return string?                 error
 function server:new(opts) end
+
+---Send a continuation frame
+---@param  data?    string
+---@return integer? bytes
+---@return string?  error
+function server:send_continue(data) end
 
 return server

--- a/library/resty/websocket/server.lua
+++ b/library/resty/websocket/server.lua
@@ -1,9 +1,9 @@
 ---@meta
 
 ---@class resty.websocket.server : resty.websocket
-local server = {
-	_VERSION = "0.09",
-}
+---
+---@field _VERSION string
+local server = {}
 
 ---Performs the websocket handshake process on the server side and returns a WebSocket server object.
 ---

--- a/library/tablepool.lua
+++ b/library/tablepool.lua
@@ -1,4 +1,10 @@
 ---@meta
+
+-- lua-tablepool
+--
+-- Lua table recycling pools for LuaJIT
+--
+-- https://github.com/openresty/lua-tablepool
 local tablepool = {}
 
 --- Releases the already used Lua table, `tb`, into the table pool named `pool_name`. If the specified table pool does not exist, create it right away.


### PR DESCRIPTION
Spent an afternoon this weekend doing an incremental update on OpenResty typedefs.

Highlights:

* `*`
  * various style cleanup chores:
    * rename `resty_core_<thing>` local var to `<thing>`
    * prefer `@field version string` to various hardcoded values
    * update old-style string literals/constants (`'"foo"'` => `"foo"`)
    * fix some typos
* `ngx`
  * New: `ngx.socket.tcp:bind()`
  * New: `ngx.socket.udp:bind()`
* `ngx.balancer`
  * New: `set_upstream_tls()`
* `ngx.ssl`
  * New: `parse_der_cert()`
  * New: `parse_der_priv_key()`
  * New: `get_req_ssl_pointer()`
  * New: `export_keying_material()`
  * New: `export_keying_material_early()`
  * New: `get_client_random()`
  * Updated: `get_tls1_version_str()` returns `ngx.ssl.tls_version.string`
  * Updated: `get_tls1_version()` returns `ngx.ssl.tls_version.integer`
* `ngx.ssl.clienthello`
  * New: `get_supported_versions()`
  * Updated: `set_protocols()` expects `ngx.ssl.tls_version.string[]`
* `resty.aes`
  * Updated: `encrypt()` and `decrypt()` methods accept optional `aad` param
* `resty.websocket`
  * Updated: move some unique child class fields from `resty.websocket` to `resty.websocket.server`/`resty.websocket.client`
  * Updated: `resty.websocket.new.opts`:
    * New: `max_send_len`
    * New: `max_recv_len`
  * Updated: `resty.websocket.client.connect.opts`
    * New: `pool_size
    * New: `backlog`
    * New: `host`
    * New: `server_name`
    * New: `client_cert`
    * New: `client_priv_key`
  * Updated: `resty.websocket.server`
    * New: `send_continue()` method
* `resty.core.time`
  * New: `monotonic_time()`
  * New: `monotonic_msec()`
* `resty.dns.resolver`
  * Updated: `resty.dns.resolver.nameserver_tuple` uses new tuple type
  * New: `destroy()` method
* `resty.upstream.healthcheck`
  * New: added annotations
* `resty.upload`
  * New: added annotations

**NOTE:** Some of the updates here (e.g. `resty.websocket`) are in master but have not yet been in an official OpenResty release just yet. I wish LuaLS had some concept of library/package versions so we could properly differentiate :(